### PR TITLE
Fix timer ID mismatch in Windows table indeterminate progress bar

### DIFF
--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -226,7 +226,7 @@ int uiprivTableProgress(uiTable *t, int item, int subitem, int modelColumn, LONG
 		if (SetTimer(t->hwnd, (UINT_PTR) t, 30, NULL) == 0)
 			logLastError(L"SetTimer()");
 	if (stopTimer)
-		if (KillTimer(t->hwnd, (UINT_PTR) (&t)) == 0)
+		if (KillTimer(t->hwnd, (UINT_PTR) t) == 0)
 			logLastError(L"KillTimer()");
 
 	return progress;


### PR DESCRIPTION
Hi @petabyt 

A timer ID mismatch was occurring in the Windows table implementation during indeterminate progress bar (progress value -1) animation processing.

## Issue Details

- `SetTimer()` and `KillTimer()` were using different timer IDs
- `SetTimer()`: Used `(UINT_PTR) t`
- `KillTimer()`: Used `(UINT_PTR) (&t)` (incorrect)
- This caused `KillTimer()` to fail, resulting in timer resource leaks

See https://github.com/libui-ng/libui-ng/pull/324