### PR TITLE
windows: Fixed arc drawing sweep direction to match Unix/Mac platforms

### DIFF
--- a/windows/drawpath.cpp
+++ b/windows/drawpath.cpp
@@ -143,9 +143,9 @@ static void drawArc(uiDrawPath *p, struct arc *a, void (*startFunction)(uiDrawPa
 	as.size.height = a->radius;
 	as.rotationAngle = 0;		// as above, not relevant for circles
 	if (a->negative)
-		as.sweepDirection = D2D1_SWEEP_DIRECTION_COUNTER_CLOCKWISE;
-	else
 		as.sweepDirection = D2D1_SWEEP_DIRECTION_CLOCKWISE;
+	else
+		as.sweepDirection = D2D1_SWEEP_DIRECTION_COUNTER_CLOCKWISE;
 	// TODO explain the outer if
 	if (!a->negative)
 		if (a->sweep > uiPi)


### PR DESCRIPTION
- Changed `negative` parameter logic in `drawArc` function

See: https://github.com/libui-ng/libui-ng/pull/341